### PR TITLE
Fix syntax highlighting for strings with double-colons

### DIFF
--- a/language/ahk.tmLanguage.yaml
+++ b/language/ahk.tmLanguage.yaml
@@ -73,7 +73,7 @@ repository:
             name: entity.name.function.label.ahk
           '2':
             name: punctuation.definition.equals.colon
-        match: ^\s*(.+)(::)
+        match: ^\s*([^\"]+)(::)
         name: hotkeyline.ahk
         example: '^c::'
   function-call:

--- a/src/test/suite/grammar/samples/54-double-colon-in-string.ahk
+++ b/src/test/suite/grammar/samples/54-double-colon-in-string.ahk
@@ -1,0 +1,3 @@
+;[#54 in AHK+](https://github.com/vscode-autohotkey/autohotkey-plus/issues/54)
+Hotstring("::ykhis", "you know how it is")
+Hotstring(":C:OOS", "out-of::-spec")

--- a/src/test/suite/grammar/samples/54-double-colon-in-string.ahk.snap
+++ b/src/test/suite/grammar/samples/54-double-colon-in-string.ahk.snap
@@ -1,25 +1,27 @@
+>;[#54 in AHK+](https://github.com/vscode-autohotkey/autohotkey-plus/issues/54)
+#^ source.ahk comment.line.semicolon.ahk punctuation.definition.comment.ahk
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk comment.line.semicolon.ahk
 >Hotstring("::ykhis", "you know how it is")
-#^^^^^^^^^^^ source.ahk hotkeyline.ahk entity.name.function.label.ahk
-#           ^^ source.ahk hotkeyline.ahk punctuation.definition.equals.colon
-#             ^^^^^ source.ahk variable.def.ahk
-#                  ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
-#                   ^^ source.ahk string.quoted.double.ahk
-#                     ^ source.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
-#                      ^^^ source.ahk variable.def.ahk
-#                         ^ source.ahk
-#                          ^^^^ source.ahk variable.def.ahk
-#                              ^ source.ahk
-#                               ^^^ source.ahk variable.def.ahk
-#                                  ^ source.ahk
-#                                   ^^ source.ahk variable.def.ahk
-#                                     ^ source.ahk
-#                                      ^^ source.ahk keyword.other.ahk
-#                                        ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
-#                                         ^^ source.ahk string.quoted.double.ahk
+#^^^^^^^^^ source.ahk entity.name.function.ahk
+#         ^ source.ahk punctuation.bracket.ahk
+#          ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#           ^^^^^^^ source.ahk string.quoted.double.ahk
+#                  ^ source.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
+#                   ^ source.ahk punctuation.ahk
+#                    ^ source.ahk
+#                     ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#                      ^^^^^^^^^^^^^^^^^^ source.ahk string.quoted.double.ahk
+#                                        ^ source.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
+#                                         ^ source.ahk punctuation.bracket.ahk
 >Hotstring(":C:OOS", "out-of::-spec")
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk hotkeyline.ahk entity.name.function.label.ahk
-#                           ^^ source.ahk hotkeyline.ahk punctuation.definition.equals.colon
-#                             ^ source.ahk keyword.operator.arithmetic.ahk
-#                              ^^^^ source.ahk variable.def.ahk
-#                                  ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
-#                                   ^^ source.ahk string.quoted.double.ahk
+#^^^^^^^^^ source.ahk entity.name.function.ahk
+#         ^ source.ahk punctuation.bracket.ahk
+#          ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#           ^^^^^^ source.ahk string.quoted.double.ahk
+#                 ^ source.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
+#                  ^ source.ahk punctuation.ahk
+#                   ^ source.ahk
+#                    ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#                     ^^^^^^^^^^^^^ source.ahk string.quoted.double.ahk
+#                                  ^ source.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
+#                                   ^ source.ahk punctuation.bracket.ahk

--- a/src/test/suite/grammar/samples/54-double-colon-in-string.ahk.snap
+++ b/src/test/suite/grammar/samples/54-double-colon-in-string.ahk.snap
@@ -1,0 +1,25 @@
+>Hotstring("::ykhis", "you know how it is")
+#^^^^^^^^^^^ source.ahk hotkeyline.ahk entity.name.function.label.ahk
+#           ^^ source.ahk hotkeyline.ahk punctuation.definition.equals.colon
+#             ^^^^^ source.ahk variable.def.ahk
+#                  ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#                   ^^ source.ahk string.quoted.double.ahk
+#                     ^ source.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
+#                      ^^^ source.ahk variable.def.ahk
+#                         ^ source.ahk
+#                          ^^^^ source.ahk variable.def.ahk
+#                              ^ source.ahk
+#                               ^^^ source.ahk variable.def.ahk
+#                                  ^ source.ahk
+#                                   ^^ source.ahk variable.def.ahk
+#                                     ^ source.ahk
+#                                      ^^ source.ahk keyword.other.ahk
+#                                        ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#                                         ^^ source.ahk string.quoted.double.ahk
+>Hotstring(":C:OOS", "out-of::-spec")
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk hotkeyline.ahk entity.name.function.label.ahk
+#                           ^^ source.ahk hotkeyline.ahk punctuation.definition.equals.colon
+#                             ^ source.ahk keyword.operator.arithmetic.ahk
+#                              ^^^^ source.ahk variable.def.ahk
+#                                  ^ source.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#                                   ^^ source.ahk string.quoted.double.ahk


### PR DESCRIPTION
Strings with double colons in them are now highlighted correctly (GitHub may render incorrectly):

```ahk
Hotstring("::ykhis", "you know how it is")
Hotstring(":C:OOS", "out-of::-spec")
```

![code with correct highlighting](https://user-images.githubusercontent.com/7833360/203520008-14351b9c-5df1-40a0-8717-804ca6344eed.png)
